### PR TITLE
Add state and locality

### DIFF
--- a/CertificateSigningRequestSwift.xcodeproj/project.pbxproj
+++ b/CertificateSigningRequestSwift.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		910920A31E788CB1008E5535 /* CertificateSigningRequestSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910920A21E788CB1008E5535 /* CertificateSigningRequestSwiftTests.swift */; };
 		917B68901DD0F4FD00AE5629 /* CertificateSigningRequestSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 917B68861DD0F4FD00AE5629 /* CertificateSigningRequestSwift.framework */; };
 		91B5FF9E1F81A19E0074ECF4 /* CertificateSigningRequestSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5FF9D1F81A19E0074ECF4 /* CertificateSigningRequestSwift.swift */; };
-		91C5B0B71F8AA7FB009323A6 /* CertificateSigningRequestSwiftn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C5B0B61F8AA7FB009323A6 /* CertificateSigningRequestSwiftn.swift */; };
 		91C5B0B91F8ADB91009323A6 /* CertificateSigningRequestSwiftConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C5B0B81F8ADB91009323A6 /* CertificateSigningRequestSwiftConstants.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,7 +37,6 @@
 		91B5FF9D1F81A19E0074ECF4 /* CertificateSigningRequestSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateSigningRequestSwift.swift; sourceTree = "<group>"; };
 		91B5FF9F1F81A3370074ECF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		91B5FFA01F81A3700074ECF4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		91C5B0B61F8AA7FB009323A6 /* CertificateSigningRequestSwiftn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateSigningRequestSwiftn.swift; sourceTree = "<group>"; };
 		91C5B0B81F8ADB91009323A6 /* CertificateSigningRequestSwiftConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateSigningRequestSwiftConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -97,7 +95,6 @@
 			children = (
 				91C5B0B81F8ADB91009323A6 /* CertificateSigningRequestSwiftConstants.swift */,
 				91B5FF9D1F81A19E0074ECF4 /* CertificateSigningRequestSwift.swift */,
-				91C5B0B61F8AA7FB009323A6 /* CertificateSigningRequestSwiftn.swift */,
 				91AA931A1F7C810000AE23E0 /* CertificateSigningRequestSwift.h */,
 				910921721E79DE64008E5535 /* CommonCrypto.xcconfig */,
 				91B5FF9F1F81A3370074ECF4 /* Info.plist */,
@@ -227,7 +224,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91C5B0B71F8AA7FB009323A6 /* CertificateSigningRequestSwiftn.swift in Sources */,
 				91B5FF9E1F81A19E0074ECF4 /* CertificateSigningRequestSwift.swift in Sources */,
 				91C5B0B91F8ADB91009323A6 /* CertificateSigningRequestSwiftConstants.swift in Sources */,
 			);

--- a/CertificateSigningRequestSwift/CertificateSigningRequestSwift.swift
+++ b/CertificateSigningRequestSwift/CertificateSigningRequestSwift.swift
@@ -34,19 +34,19 @@ import Foundation
 public class CertificateSigningRequest:NSObject {
     private let OBJECT_commonName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x03]
     private let OBJECT_countryName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x06]
-    private let OBJECT_stateOrProvinceName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x08]
     private let OBJECT_localityName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x07]
     private let OBJECT_organizationName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x0A]
     private let OBJECT_organizationalUnitName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x0B]
+    private let OBJECT_stateOrProvinceName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x08]
     private let SEQUENCE_tag:UInt8 = 0x30
     private let SET_tag:UInt8 = 0x31
     
+    private let commonName:String?
     private let countryName:String?
-    private let stateOrProvinceName:String?
     private let localityName:String?
     private let organizationName:String?
     private let organizationUnitName:String?
-    private let commonName:String?
+    private let stateOrProvinceName:String?
     private var keyAlgorithm: KeyAlgorithm!
     private var subjectDER:Data?
     

--- a/CertificateSigningRequestSwift/CertificateSigningRequestSwift.swift
+++ b/CertificateSigningRequestSwift/CertificateSigningRequestSwift.swift
@@ -34,12 +34,16 @@ import Foundation
 public class CertificateSigningRequest:NSObject {
     private let OBJECT_commonName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x03]
     private let OBJECT_countryName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x06]
+    private let OBJECT_stateOrProvinceName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x08]
+    private let OBJECT_localityName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x07]
     private let OBJECT_organizationName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x0A]
     private let OBJECT_organizationalUnitName:[UInt8] = [0x06, 0x03, 0x55, 0x04, 0x0B]
     private let SEQUENCE_tag:UInt8 = 0x30
     private let SET_tag:UInt8 = 0x31
     
     private let countryName:String?
+    private let stateOrProvinceName:String?
+    private let localityName:String?
     private let organizationName:String?
     private let organizationUnitName:String?
     private let commonName:String?
@@ -47,12 +51,14 @@ public class CertificateSigningRequest:NSObject {
     private var subjectDER:Data?
     
     
-    public init(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, keyAlgorithm: KeyAlgorithm){
+    public init(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, stateOrProvinceName:String?, localityName:String?, keyAlgorithm: KeyAlgorithm){        
         
         self.commonName = commonName
         self.organizationName = organizationName
         self.organizationUnitName = organizationUnitName
         self.countryName = countryName
+        self.stateOrProvinceName = stateOrProvinceName
+        self.localityName = localityName
         self.subjectDER = nil
         self.keyAlgorithm = keyAlgorithm
         
@@ -60,11 +66,11 @@ public class CertificateSigningRequest:NSObject {
     }
     
     public convenience override init(){
-        self.init(commonName: nil, organizationName:nil, organizationUnitName:nil, countryName:nil, keyAlgorithm: KeyAlgorithm.rsa(signatureType: .sha512))
+        self.init(commonName: nil, organizationName:nil, organizationUnitName:nil, countryName:nil, stateOrProvinceName:nil, localityName:nil, keyAlgorithm: KeyAlgorithm.rsa(signatureType: .sha512))
     }
     
     public convenience init(keyAlgorithm: KeyAlgorithm){
-        self.init(commonName: nil, organizationName:nil, organizationUnitName:nil, countryName:nil, keyAlgorithm: keyAlgorithm)
+        self.init(commonName: nil, organizationName:nil, organizationUnitName:nil, countryName:nil, stateOrProvinceName:nil, localityName:nil, keyAlgorithm: keyAlgorithm)
     }
     
     public func build(_ publicKeyBits:Data, privateKey: SecKey) -> Data?{
@@ -214,6 +220,14 @@ public class CertificateSigningRequest:NSObject {
         var subject = Data(capacity: 256)
         if countryName != nil{
             appendSubjectItem(OBJECT_countryName, value: countryName!, into: &subject)
+        }
+        
+        if stateOrProvinceName != nil {
+            appendSubjectItem(OBJECT_stateOrProvinceName, value: stateOrProvinceName!, into: &subject)
+        }
+        
+        if localityName != nil {
+            appendSubjectItem(OBJECT_localityName, value: localityName!, into: &subject)
         }
         
         if organizationName != nil{

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additions have been made to support RSA and EC (iOS only supports 256 bit keys f
 To use, initiatlize the class using one of the following (an example of how to do can be found at https://github.com/cbaker6/CertificateSigningRequestSwift/blob/master/CertificateSigningRequestSwiftTests/CertificateSigningRequestSwiftTests.swift): 
 - `let csr = CertificateSigningRequest()`
 - `let csr = CertificateSigningRequest(keyAlgorithm: KeyAlgorithm)`
-- `let csr = CertificateSigningRequest(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, keyAlgorithm: KeyAlgorithm)`
+- `let csr = CertificateSigningRequest(commonName: String?, organizationName:String?, organizationUnitName:String?, countryName:String?, stateOrProvinceName:String?, localityName:String?, keyAlgorithm: KeyAlgorithm)`
 
 Then simply build your CSR using your publicKey(bits) and privateKey using, `let builtCSR = csr.buildCSRAndReturnString(publicKeyBits, privateKey: privateKey)`.
 


### PR DESCRIPTION
Our registration authority requires us to submit state and locality in our CSR.  These changes add the ability to set a state or province name and locality.